### PR TITLE
Update retriable errors to match DynamoDB guide

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+`2.1.3`_ (27 Jan 2017)
+----------------------
+- Add HTTP Internal Server Error (500) and Service Unavailable (503) to retriable exceptions
+
 `2.1.2`_ (28 Oct 2016)
 ----------------------
 - Change the pinning of tornado-aws to open it up a little wider
@@ -42,7 +46,8 @@ Release History
 `Next Release`_
 ---------------
 
-.. _Next Release: https://github.com/sprockets/sprockets_dynamodb/compare/2.1.2...master
+.. _Next Release: https://github.com/sprockets/sprockets_dynamodb/compare/2.1.3...master
+.. _2.1.3: https://github.com/sprockets/sprockets-dynamodb/compare/2.1.2...2.1.3
 .. _2.1.2: https://github.com/sprockets/sprockets-dynamodb/compare/2.1.1...2.1.2
 .. _2.1.1: https://github.com/sprockets/sprockets-dynamodb/compare/2.1.0...2.1.1
 .. _2.1.0: https://github.com/sprockets/sprockets-dynamodb/compare/2.0.0...2.1.0

--- a/sprockets_dynamodb/__init__.py
+++ b/sprockets_dynamodb/__init__.py
@@ -18,7 +18,7 @@ try:
 except ImportError:  # pragma: nocover
     pass
 
-version_info = (2, 1, 2)
+version_info = (2, 1, 3)
 __version__ = '.'.join(str(v) for v in version_info)
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/sprockets_dynamodb/client.py
+++ b/sprockets_dynamodb/client.py
@@ -772,9 +772,11 @@ class Client(object):
             try:
                 result = yield self._execute(
                     action, parameters, attempt, measurements)
-            except (exceptions.RequestException,
+            except (exceptions.InternalServerError,
+                    exceptions.RequestException,
                     exceptions.ThrottlingException,
-                    exceptions.ThroughputExceeded) as error:
+                    exceptions.ThroughputExceeded,
+                    exceptions.ServiceUnavailable) as error:
                 if attempt == self._max_retries:
                     if self._instrumentation_callback:
                         self._instrumentation_callback(measurements)

--- a/sprockets_dynamodb/exceptions.py
+++ b/sprockets_dynamodb/exceptions.py
@@ -42,6 +42,14 @@ class InternalFailure(DynamoDBException):
     pass
 
 
+class InternalServerError(DynamoDBException):
+    """The request processing has failed because DynamoDB could not process
+    your request.
+
+    """
+    pass
+
+
 class ItemCollectionSizeLimitExceeded(DynamoDBException):
     """An item collection is too large. This exception is only returned for
     tables that have one or more local secondary indexes.
@@ -196,6 +204,8 @@ MAP = {
     'com.amazonaws.dynamodb.v20120810#ItemCollectionSizeLimitExceededException':
     ItemCollectionSizeLimitExceeded,
     'com.amazonaws.dynamodb.v20120810#InternalFailure': InternalFailure,
+    'com.amazonaws.dynamodb.v20120810#InternalServerError':
+    InternalServerError,
     'com.amazonaws.dynamodb.v20120810#LimitExceededException': LimitExceeded,
     'com.amazonaws.dynamodb.v20120810#ProvisionedThroughputExceededException':
     ThroughputExceeded,
@@ -204,5 +214,7 @@ MAP = {
     ResourceNotFound,
     'com.amazonaws.dynamodb.v20120810#ThrottlingException':
     ThrottlingException,
-    'com.amazon.coral.validate#ValidationException': ValidationException
+    'com.amazon.coral.validate#ValidationException': ValidationException,
+    'com.amazonaws.dynamodb.v20120810#ServiceUnavailable':
+    ServiceUnavailable
 }


### PR DESCRIPTION
Add HTTP Internal Server Error (500) and Service Unavailable (503) to be retried defined number of times based on developer guide recommendations.

See developer guide below for more information: http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Programming.Errors.html#Programming.Errors.MessagesAndCodes