### PR TITLE
Retry upon tornado_aws.exceptions.AWSClientException

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -33,20 +33,13 @@ else
   exit 2
 fi
 
-COMPOSE_ARGS=
-if test -n "${DOCKER_COMPOSE_PREFIX}"
-then
-  COMPOSE_ARGS="-p ${DOCKER_COMPOSE_PREFIX}"
-fi
-
 get_exposed_port() {
-  docker-compose ${COMPOSE_ARGS} port $1 $2 | cut -d: -f2
+  docker-compose port $1 $2 | cut -d: -f2
 }
 
 build_env_file() {
   DYNAMODB_PORT=$(get_exposed_port dynamodb 7777)
-  (echo "export DOCKER_COMPOSE_PREFIX=${DOCKER_COMPOSE_PREFIX}"
-   echo "export DOCKER_TLS_VERIFY=${DOCKER_TLS_VERIFY}"
+  (echo "export DOCKER_TLS_VERIFY=${DOCKER_TLS_VERIFY}"
    echo "export DOCKER_HOST=${DOCKER_HOST}"
    echo "export DOCKER_CERT_PATH=${DOCKER_CERT_PATH}"
    echo "export DOCKER_MACHINE_NAME=${DOCKER_MACHINE_NAME}"
@@ -63,9 +56,8 @@ then
   # just build the environment file from docker containers
   build_env_file build/test-environment
 else
-  docker-compose ${COMPOSE_ARGS} stop
-  docker-compose ${COMPOSE_ARGS} rm --force
-  docker-compose ${COMPOSE_ARGS} up -d
+  docker-compose down --volumes --remove-orphans
+  docker-compose up -d
   build_env_file build/test-environment
 fi
 cat build/test-environment

--- a/sprockets_dynamodb/client.py
+++ b/sprockets_dynamodb/client.py
@@ -772,7 +772,8 @@ class Client(object):
             try:
                 result = yield self._execute(
                     action, parameters, attempt, measurements)
-            except (exceptions.InternalServerError,
+            except (aws_exceptions.AWSClientException,
+                    exceptions.InternalServerError,
                     exceptions.RequestException,
                     exceptions.ThrottlingException,
                     exceptions.ThroughputExceeded,

--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -234,6 +234,28 @@ class AWSClientTests(AsyncTestCase):
 
         yield wait_for_measurements.wait()
 
+    @testing.gen_test
+    def test_awsclient_exception_has_max_retries_measurements(self):
+        definition = self.generic_table_definition()
+
+        wait_for_measurements = locks.Event()
+
+        def instrumentation_check(measurements):
+            for attempt, measurement in enumerate(measurements):
+                self.assertEqual(measurement.error, 'AWSClientException')
+            self.assertEqual(len(measurements), 3)
+            wait_for_measurements.set()
+
+        self.client.set_instrumentation_callback(instrumentation_check)
+        with mock.patch('tornado_aws.client.AsyncAWSClient.fetch') as fetch:
+            future = concurrent.Future()
+            fetch.return_value = future
+            future.set_exception(aws_exceptions.AWSClientException())
+            with self.assertRaises(aws_exceptions.AWSClientException):
+                yield self.client.create_table(definition)
+
+        yield wait_for_measurements.wait()
+
 
 class CreateTableTests(AsyncTestCase):
 


### PR DESCRIPTION
Retry currently does not work when tornado_aws.AWSClient.fetch raises an AWSClientException.
https://github.com/gmr/tornado-aws/blob/master/tornado_aws/client.py#L172-L174