### PR TITLE
Handle tornado_aws.exceptions.RequestException during execute

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -33,25 +33,14 @@ else
   exit 2
 fi
 
-COMPOSE_ARGS=
-if test -n "${DOCKER_COMPOSE_PREFIX}"
-then
-  COMPOSE_ARGS="-p ${DOCKER_COMPOSE_PREFIX}"
-fi
-
 get_exposed_port() {
-  docker-compose ${COMPOSE_ARGS} port $1 $2 | cut -d: -f2
+  docker-compose port $1 $2 | cut -d: -f2
 }
 
 build_env_file() {
-  DYNAMODB_PORT=$(get_exposed_port dynamodb 7777)
-  (echo "export DOCKER_COMPOSE_PREFIX=${DOCKER_COMPOSE_PREFIX}"
-   echo "export DOCKER_TLS_VERIFY=${DOCKER_TLS_VERIFY}"
-   echo "export DOCKER_HOST=${DOCKER_HOST}"
-   echo "export DOCKER_CERT_PATH=${DOCKER_CERT_PATH}"
-   echo "export DOCKER_MACHINE_NAME=${DOCKER_MACHINE_NAME}"
-   echo "export DYNAMODB_ENDPOINT=http://${DOCKER_IP}:${DYNAMODB_PORT}"
-  ) > $1
+cat > $1<<EOF
+export DYNAMODB_ENDPOINT=http://${DOCKER_IP}:$(get_exposed_port dynamodb 7777)
+EOF
 }
 
 set -e
@@ -63,9 +52,8 @@ then
   # just build the environment file from docker containers
   build_env_file build/test-environment
 else
-  docker-compose ${COMPOSE_ARGS} stop
-  docker-compose ${COMPOSE_ARGS} rm --force
-  docker-compose ${COMPOSE_ARGS} up -d
+  docker-compose down --volumes --remove-orphans
+  docker-compose up -d
   build_env_file build/test-environment
 fi
 cat build/test-environment

--- a/requires/installation.txt
+++ b/requires/installation.txt
@@ -1,2 +1,2 @@
-tornado-aws>=0.8,<1
+tornado-aws>=1.0,<2
 tornado>=4.0

--- a/sprockets_dynamodb/client.py
+++ b/sprockets_dynamodb/client.py
@@ -888,7 +888,8 @@ class Client(object):
             exception = exceptions.NoProfileError(str(error))
         except aws_exceptions.AWSError as error:
             exception = exceptions.DynamoDBException(error)
-        except (ConnectionError, ConnectionResetError, OSError, ssl.SSLError,
+        except (ConnectionError, ConnectionResetError, OSError,
+                aws_exceptions.RequestException, ssl.SSLError,
                 _select.error, ssl.socket_error, socket.gaierror) as error:
             exception = exceptions.RequestException(str(error))
         except TimeoutError:

--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -182,6 +182,10 @@ class AWSClientTests(AsyncTestCase):
         self.create_table_expecting_raise(dynamodb.RequestException,
                                           TimeoutError)
 
+    def test_tornado_aws_request_exception(self):
+        self.create_table_expecting_raise(dynamodb.RequestException,
+                                          aws_exceptions.RequestException(error=OSError))
+
     @testing.gen_test
     def test_retriable_exception_has_max_retries_measurements(self):
         definition = self.generic_table_definition()

--- a/tests/api_tests.py
+++ b/tests/api_tests.py
@@ -117,6 +117,7 @@ class AsyncItemTestCase(AsyncTestCase):
 
 class AWSClientTests(AsyncTestCase):
 
+    @testing.gen_test
     def create_table_expecting_raise(self, exception, future_exception=None):
         with mock.patch('tornado_aws.client.AsyncAWSClient.fetch') as fetch:
             future = concurrent.Future()
@@ -125,67 +126,61 @@ class AWSClientTests(AsyncTestCase):
             with self.assertRaises(exception):
                 yield self.client.create_table(self.generic_table_definition())
 
-    @testing.gen_test
     def test_raises_config_not_found_exception(self):
         self.create_table_expecting_raise(
-            aws_exceptions.ConfigNotFound,
+            dynamodb.ConfigNotFound,
             aws_exceptions.ConfigNotFound(path='/test'))
 
-    @testing.gen_test
     def test_raises_config_parser_error(self):
-        self.create_table_expecting_raise(aws_exceptions.ConfigParserError,
+        self.create_table_expecting_raise(dynamodb.ConfigParserError,
                                           aws_exceptions.ConfigParserError(
                                               path='/test'))
 
-    @testing.gen_test
     def test_raises_no_credentials_error(self):
-        self.create_table_expecting_raise(aws_exceptions.NoCredentialsError)
+        self.create_table_expecting_raise(dynamodb.NoCredentialsError,
+                                          aws_exceptions.NoCredentialsError)
 
-    @testing.gen_test
     def test_raises_no_profile_error(self):
         self.create_table_expecting_raise(
-            aws_exceptions.NoProfileError,
+            dynamodb.NoProfileError,
             aws_exceptions.NoProfileError(profile='test-1', path='/test'))
 
-    @testing.gen_test
     def test_raises_request_exception(self):
-        self.create_table_expecting_raise(httpclient.HTTPError,
+        self.create_table_expecting_raise(dynamodb.RequestException,
                                           httpclient.HTTPError(500, 'uh-oh'))
 
-    @testing.gen_test
     def test_raises_timeout_exception(self):
-        self.create_table_expecting_raise(httpclient.HTTPError,
+        self.create_table_expecting_raise(dynamodb.TimeoutException,
                                           httpclient.HTTPError(599))
 
-    @testing.gen_test
     def test_empty_fetch_response_raises_dynamodb_exception(self):
         self.create_table_expecting_raise(dynamodb.DynamoDBException)
 
-    @testing.gen_test
     def test_gaierror_raises_request_exception(self):
-        self.create_table_expecting_raise(socket.gaierror)
+        self.create_table_expecting_raise(dynamodb.RequestException,
+                                          socket.gaierror)
 
-    @testing.gen_test
     def test_oserror_raises_request_exception(self):
-        self.create_table_expecting_raise(OSError)
+        self.create_table_expecting_raise(dynamodb.RequestException,
+                                          OSError)
 
     @unittest.skipIf(sys.version_info.major < 3,
                      'ConnectionError is Python3 only')
-    @testing.gen_test
     def test_connection_error_request_exception(self):
-        self.create_table_expecting_raise(ConnectionError)
+        self.create_table_expecting_raise(dynamodb.RequestException,
+                                          ConnectionError)
 
     @unittest.skipIf(sys.version_info.major < 3,
                      'ConnectionResetError is Python3 only')
-    @testing.gen_test
     def test_connection_reset_error_request_exception(self):
-        self.create_table_expecting_raise(ConnectionResetError)
+        self.create_table_expecting_raise(dynamodb.RequestException,
+                                          ConnectionResetError)
 
     @unittest.skipIf(sys.version_info.major < 3,
                      'TimeoutError is Python3 only')
-    @testing.gen_test
     def test_connection_timeout_error_request_exception(self):
-        self.create_table_expecting_raise(TimeoutError)
+        self.create_table_expecting_raise(dynamodb.RequestException,
+                                          TimeoutError)
 
     @testing.gen_test
     def test_retriable_exception_has_max_retries_measurements(self):


### PR DESCRIPTION
When an OS or socket error occurs in `tornado_aws.AWSClient.fetch`, a `tornado_aws.exception.RequestException` is raised. Since this is currently unhandled, it will break the retry logic in `sprockets_dynamodb.Client` and be exposed directly to the caller.

This PR captures said exception and raises a `sprockets_dynamodb.RequestException` in its place - this allowing the retry logic to function.

`tornado_aws.exception.RequestException` was introduced in `tornado-aws` 1.0.0 so our requirement pin was updated.

Additional changes:
- Fix the existing exception handling tests - the simply did not work.
- General bootstrap cleanup/cruft removal.