### PR TITLE
Support Tornado 5

### DIFF
--- a/examples/create-table.py
+++ b/examples/create-table.py
@@ -46,7 +46,7 @@ TABLE_DEF = {
 }
 
 dynamo = dynamodb.Client()
-iol = ioloop.IOLoop.instance()
+iol = ioloop.IOLoop.current()
 
 
 def on_table_described(describe_response):

--- a/requires/installation.txt
+++ b/requires/installation.txt
@@ -1,2 +1,2 @@
 tornado-aws>=1.0,<2
-tornado>=4.0,<5
+tornado>=4.0,<6

--- a/sprockets_dynamodb/client.py
+++ b/sprockets_dynamodb/client.py
@@ -833,7 +833,7 @@ class Client(object):
         :rtype: tornado.concurrent.Future
 
         """
-        future = concurrent.TracebackFuture()
+        future = concurrent.Future()
         start = time.time()
 
         def handle_response(request):


### PR DESCRIPTION
Tornado 5 removed the deprecated TracebackFuture. Future may be used as a drop-in replacement.

Blocked by https://github.com/gmr/tornado-aws/pull/11