### PR TITLE
Fix for saftely retrieving the Attributes in results when there is no record to delete

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -3,6 +3,10 @@
 Release History
 ===============
 
+`3.0.2`_ (24 May 2019)
+----------------------
+- Saftely retrieve Attributes key in unwrap_delete_put_update_item for local dev
+
 `3.0.1`_ (02 May 2019)
 ----------------------
 - Change the pinning of Tornado to support Tornado 6
@@ -64,7 +68,8 @@ Release History
 `Next Release`_
 ---------------
 
-.. _Next Release: https://github.com/sprockets/sprockets_dynamodb/compare/3.0.1...master
+.. _Next Release: https://github.com/sprockets/sprockets_dynamodb/compare/3.0.2...master
+.. _3.0.2: https://github.com/sprockets/sprockets-dynamodb/compare/3.0.1...3.0.2
 .. _3.0.1: https://github.com/sprockets/sprockets-dynamodb/compare/3.0.0...3.0.1
 .. _3.0.0: https://github.com/sprockets/sprockets-dynamodb/compare/2.2.0...3.0.0
 .. _2.3.0: https://github.com/sprockets/sprockets-dynamodb/compare/2.2.0...2.3.0

--- a/sprockets_dynamodb/__init__.py
+++ b/sprockets_dynamodb/__init__.py
@@ -18,7 +18,7 @@ try:
 except ImportError:  # pragma: nocover
     pass
 
-version_info = (3, 0, 1)
+version_info = (3, 0, 2)
 __version__ = '.'.join(str(v) for v in version_info)
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/sprockets_dynamodb/client.py
+++ b/sprockets_dynamodb/client.py
@@ -966,7 +966,7 @@ def _unwrap_result(action, result):
 
 def _unwrap_delete_put_update_item(result):
     response = {
-       'Attributes': utils.unmarshall(result['Attributes'] if result else {})
+       'Attributes': utils.unmarshall(result.get('Attributes', {}) if result else {})
     }
     if 'ConsumedCapacity' in result:
         response['ConsumedCapacity'] = result['ConsumedCapacity']


### PR DESCRIPTION
**Reason for PR**
Had tests failing when testing the error case that someone tries to delete something that doesnt exist in dynamodb. 
```
Tests were failing with following error:
line 975 in _unwrap_delete_put_update_item
'Attributes': utils.unmarshall(result['Attributes'] if result else {})
KeyError: 'Attributes'
```
Our local dynamodb is breaking the contract and returning data about the table and its consumed capacity.

**What was Done**
- Added a `result.get('Attributes', {})` to make sure it can continue on cleanly.
  - Default needed because if there is a result but the key does not exist the iteration later on in the function will break
  - kept if...else at end of line incase result might be None.
- Bumped version