### PR TITLE
Convert 0 length strings to the NULL type

### DIFF
--- a/sprockets_dynamodb/__init__.py
+++ b/sprockets_dynamodb/__init__.py
@@ -18,7 +18,7 @@ try:
 except ImportError:  # pragma: nocover
     pass
 
-version_info = (3, 0, 2)
+version_info = (3, 1, 0)
 __version__ = '.'.join(str(v) for v in version_info)
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/sprockets_dynamodb/utils.py
+++ b/sprockets_dynamodb/utils.py
@@ -93,8 +93,12 @@ def _marshall_value(value):
 
     """
     if PYTHON3 and isinstance(value, bytes):
+        if not value:
+            return {'NULL': True}
         return {'B': base64.b64encode(value).decode('ascii')}
     elif PYTHON3 and isinstance(value, str):
+        if not value:
+            return {'NULL': True}
         return {'S': value}
     elif not PYTHON3 and isinstance(value, str):
         if is_binary(value):

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -41,7 +41,8 @@ class MarshallTests(unittest.TestCase):
             'key3': {
                 'sub-key1': 20,
                 'sub-key2': True,
-                'sub-key3': 'value'
+                'sub-key3': 'value',
+                'sub-key4': ''
             },
             'key4': None,
             'key5': ['one', 'two', 'three', 4, None, True],
@@ -50,7 +51,8 @@ class MarshallTests(unittest.TestCase):
             'key9': uuid_value,
             'key10': b'\0x01\0x02\0x03',
             'key11': {b'\0x01\0x02\0x03', b'\0x04\0x05\0x06'},
-            'key12': dt_value
+            'key12': dt_value,
+            'key13': ''
         }
         expectation = {
             'key1': {'S': 'str'},
@@ -59,7 +61,8 @@ class MarshallTests(unittest.TestCase):
                 'M': {
                     'sub-key1': {'N': '20'},
                     'sub-key2': {'BOOL': True},
-                    'sub-key3': {'S': 'value'}
+                    'sub-key3': {'S': 'value'},
+                    'sub-key4': {'NULL': True}
                 }
             },
             'key4': {'NULL': True},
@@ -73,7 +76,8 @@ class MarshallTests(unittest.TestCase):
             'key11': {'BS': [
                 base64.b64encode(b'\0x01\0x02\0x03').decode('ascii'),
                 base64.b64encode(b'\0x04\0x05\0x06').decode('ascii')]},
-            'key12': {'S': dt_value.isoformat()}
+            'key12': {'S': dt_value.isoformat()},
+            'key13': {'NULL': True}
         }
         self.assertDictEqual(expectation, utils.marshall(value))
 

--- a/tests/utils_tests.py
+++ b/tests/utils_tests.py
@@ -52,7 +52,8 @@ class MarshallTests(unittest.TestCase):
             'key10': b'\0x01\0x02\0x03',
             'key11': {b'\0x01\0x02\0x03', b'\0x04\0x05\0x06'},
             'key12': dt_value,
-            'key13': ''
+            'key13': '',
+            'key14': b''
         }
         expectation = {
             'key1': {'S': 'str'},
@@ -77,7 +78,8 @@ class MarshallTests(unittest.TestCase):
                 base64.b64encode(b'\0x01\0x02\0x03').decode('ascii'),
                 base64.b64encode(b'\0x04\0x05\0x06').decode('ascii')]},
             'key12': {'S': dt_value.isoformat()},
-            'key13': {'NULL': True}
+            'key13': {'NULL': True},
+            'key14': {'NULL': True}
         }
         self.assertDictEqual(expectation, utils.marshall(value))
 


### PR DESCRIPTION
Convenience for converting 0 length str/binary to the NULL type in Python 3